### PR TITLE
README note about the availability of mini_exiftool_vendored

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,7 +10,7 @@ An installation of the Exiftool command-line application.
 Instructions for installation you can find under
 http://www.sno.phy.queensu.ca/~phil/exiftool/install.html .
 
-A meta-gem that eliminates the need for a seperate Exiftool installation is also available: http://github.com/supapuerco/mini_exiftool_vendored
+A meta-gem that eliminates the need for a seperate Exiftool installation is also available: http://github.com/wilg/mini_exiftool_vendored
 
 == Installation
 


### PR DESCRIPTION
Hi Jan,

Thanks so much for integrating my `save!` method into master. The 1.6.0 release fixed all the needs I had for my own branch, except for my use case I felt it would be great to have Exiftool included in the gem.

That's probably not a good fit for what you want, so I've created a meta-gem (http://github.com/supapuerco/mini_exiftool_vendored) that does nothing but automatically set the `command=` to the bundled version. It has a gem dependency for `mini_exiftool`, so there's no duplication of code or anything.

I figured some other people might find that useful, so I've added a note about it to the readme.

Thanks,
Wil
