### PR TITLE
Switch from Shellwords.escape call to quoting when saving file to fix saving on windows

### DIFF
--- a/lib/mini_exiftool.rb
+++ b/lib/mini_exiftool.rb
@@ -162,7 +162,7 @@ class MiniExiftool
       arr_val.map! {|e| convert e}
       tag_params = ''
       arr_val.each do |v|
-        tag_params << %Q(-#{original_tag}=#{Shellwords.escape(v.to_s)} )
+        tag_params << %Q(-#{original_tag}="#{v.to_s.gsub(/"/,'\"')}" )
       end
       opt_params = ''
       opt_params << (arr_val.detect {|x| x.kind_of?(Numeric)} ? '-n ' : '')


### PR DESCRIPTION
Using Shellwords.escape leads to failure on windows systems which don't use the same escaping rules as unix. Instead opt to quote strings which should work on both systems (and escape quotes with a backslash).
