### PR TITLE
Use JSON to support control characters

### DIFF
--- a/lib/mini_exiftool.rb
+++ b/lib/mini_exiftool.rb
@@ -56,7 +56,6 @@ class MiniExiftool
     @ignore_minor_errors = opts[:ignore_minor_errors]
     @timestamps = opts[:timestamps]
     @coord_format = opts[:coord_format]
-    @supports_json = MiniExiftool.exiftool_version >= '7.65'
     @values = TagHash.new
     @tag_names = TagHash.new
     @changed_values = TagHash.new
@@ -89,8 +88,8 @@ class MiniExiftool
     opt_params << (@numerical ? '-n ' : '')
     opt_params << (@composite ? '' : '-e ')
     opt_params << (@convert_encoding ? '-L ' : '')
+    opt_params << (@@use_json ? '-j ' : '')
     opt_params << (@coord_format ? "-c \"#{@coord_format}\"" : '')
-    opt_params << (@supports_json ? '-j ' : '')
     cmd = %Q(#@@cmd -q -q -s -t #{opt_params} #{@@sep_op} #{MiniExiftool.escape(filename)})
     if run(cmd)
       parse_output
@@ -298,6 +297,7 @@ class MiniExiftool
       @@separator = '@@'
       @@sep_op = '-sep @@'
     end
+    @@use_json = MiniExiftool.exiftool_version >= '7.65'
     @@setup_done = true
   end
 
@@ -337,7 +337,7 @@ class MiniExiftool
   end
 
   def parse_output
-    if @supports_json
+    if @@use_json
       JSON.parse(@output)[0].each do |tag,value|
         value = perform_conversions(value)
         set_value tag, value


### PR DESCRIPTION
When exiftool returns tag fields on the command line it [converts control characters](http://owl.phy.queensu.ca/~phil/exiftool/faq.html#Q21) into `.`

You'll be familiar with this if you try to import images that have CR (char(13)) in the Caption-Abstract. 

This commit optionally supports the miniexif `-j` option via `use_json: true`. It will then use JSON to allow control characters in field values.

I'm happy to be told this isn't the way to do it - I just needed a solution to process text fields correctly - I can't be the only one.
