### PR TITLE
Fix before_install in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - perl Makefile.PL
   - make
   - sudo make install
+  - cd $TRAVIS_BUILD_DIR
   - exiftool -ver
   - gem install rim json
 rvm:


### PR DESCRIPTION
The .travis.yml file was cding into the Image-ExifTool-9.27 dir, but never back out again. This adds another cd to $TRAVIS_BUILD_DIR, which is where the repository is checked out.
