### PR TITLE
Fix bundler/gemspec dependencies

### DIFF
--- a/mini_exiftool.gemspec
+++ b/mini_exiftool.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<rim>.freeze, ["~> 2.9"])
   end
+  s.add_development_dependency("regtest".freeze, ["~> 0.5"])
+  s.add_development_dependency("test-unit".freeze, ["~> 3.2"])
 end


### PR DESCRIPTION
I promise this is the last PR with dependencies fix :-) 

This will allow a complete setup with `bundle install` avoiding require error messages. 

```
bundle install
bundle exec rake test
```

