### PR TITLE
fix(closed.io): given an opened IO, I expect to get it back open in c…

### DIFF
--- a/lib/mini_exiftool.rb
+++ b/lib/mini_exiftool.rb
@@ -399,7 +399,6 @@ class MiniExiftool
         rescue ::IOError => e
           raise MiniExiftool::Error.new("IO is not readable.")
         end
-        @io.close
         inp.close
       end
       @output = out.read

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -7,7 +7,7 @@ class TestIo < TestCase
   def test_simple_case
     io = open_real_io
     mini_exiftool = MiniExiftool.new(io)
-    assert io.closed?, 'IO should be closed after reading data.'
+    assert_equal false, io.closed?, 'IO should not be closed.'
     assert_equal 400, mini_exiftool.iso
   end
 


### PR DESCRIPTION
Great job for this lib. 

I'd like to highlight that when I give an open IO to mini_exiftool, I'd like to get it back opened. It's strange that the usage of this lib affect the state of my given IO [also I'm responsible to rewind the IO if necessary]

Best,
Martin