### PR TITLE
Handle additional exception RangeError in timestamp converting

### DIFF
--- a/lib/mini_exiftool.rb
+++ b/lib/mini_exiftool.rb
@@ -457,7 +457,7 @@ class MiniExiftool
         else
           raise MiniExiftool::Error.new("Value #{@opts[:timestamps]} not allowed for option timestamps.")
         end
-      rescue ArgumentError
+      rescue ArgumentError, RangeError
         value = false
       end
     when /^\+\d+\.\d+$/


### PR DESCRIPTION
Imagine a Meta Info like (real example from wildlife)
GPS Date Time: 2024:02:24 15:50:140501265154082Z

This resulted (with at least ruby 3.1.4) into
```
integer 140501265154082 too big to convert to `int'
/usr/local/rvm/rubies/ruby-3.1.4/lib/ruby/3.1.0/time.rb:264:in `utc'
/usr/local/rvm/rubies/ruby-3.1.4/lib/ruby/3.1.0/time.rb:264:in `make_time'
/usr/local/rvm/rubies/ruby-3.1.4/lib/ruby/3.1.0/time.rb:383:in `parse'
 bundle/ruby/3.1.0/gems/mini_exiftool-2.10.4/lib/mini_exiftool.rb:454:in `convert_after_load'
 ```

 Perhaps the regex should actually catch this. But I think this is a pragmatic solution