### PR TITLE
Add explicit dependency for ostruct and pstore

### DIFF
--- a/mini_exiftool.gemspec
+++ b/mini_exiftool.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
+  s.add_dependency(%q<ostruct>, [">= 0.6.0"])
+  s.add_dependency(%q<pstore>, [">= 0.1.3"])
+
   s.add_development_dependency(%q<rake>, [">= 0"])
   s.add_development_dependency(%q<rim>, ["~> 2.17"])
   s.add_development_dependency(%q<test-unit>, [">= 0"])


### PR DESCRIPTION
Starting in Ruby 3.5, `pstore` and `ostruct` will not be bundled with Ruby's default gems, and will need to be added as explicit dependencies. The deprecation warnings merged into 3.4 for [pstore][pstore] and [ostruct][ostruct] and then backported for the [release of 3.3.5][3.3.5]

[pstore]: https://github.com/ruby/ruby/pull/10430
[ostruct]: https://github.com/ruby/ruby/pull/10428
[3.3.5]: https://github.com/ruby/ruby/pull/11420