### PR TITLE
CI: Add Ruby 3.3, use bundler-cache: true

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,22 +10,19 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
           - 'ruby-head'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Install Exiftool
+        run: |
+          curl -L https://cpanmin.us | perl - --sudo Image::ExifTool
+          export PATH=/usr/local/bin:$PATH
+          exiftool -ver
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Install Exiftool
-        run: |
-          curl -L http://cpanmin.us | perl - --sudo Image::ExifTool
-          export PATH=/usr/local/bin:$PATH
-          exiftool -ver
-      - name: Install Dependencies
-        run: |
-          bundle install
+          bundler-cache: true # 'bundle install' and cache gems
       - name: Run Tests
-        run: |
-          rake
-
+        run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Exiftool
         run: |
-          curl -L https://cpanmin.us | perl - --sudo Image::ExifTool
+          curl -L --no-progress-meter https://cpanmin.us | perl - --sudo Image::ExifTool
           export PATH=/usr/local/bin:$PATH
           exiftool -ver
       - name: Set up Ruby


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.

- add Ruby 3.3
- use Bundler cache in `ruby/setup-ruby`
- use `--no-progress-meter` for curl to clarify the setup steps
- add Dependabot configuration